### PR TITLE
feat: add /api/leaderboard/devs endpoint for regular contributors

### DIFF
--- a/backend/controllers/leaderboard.controller.js
+++ b/backend/controllers/leaderboard.controller.js
@@ -1,0 +1,12 @@
+const { getRegularContributors } = require("../services/leaderboard.service");
+
+async function getDevsLeaderboard(req, res) {
+  try {
+    const data = await getRegularContributors();
+    res.status(200).json({ success: true, data });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+}
+
+module.exports = { getDevsLeaderboard };

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^6.13.0",
+        "axios": "^1.11.0",
         "bcrypt": "^6.0.0",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
@@ -504,6 +505,23 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -834,6 +852,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
@@ -964,6 +994,15 @@
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -1110,6 +1149,21 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1566,6 +1620,42 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1794,6 +1884,21 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -3075,6 +3180,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,7 @@
   "type": "commonjs",
   "dependencies": {
     "@prisma/client": "^6.13.0",
+    "axios": "^1.11.0",
     "bcrypt": "^6.0.0",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",

--- a/backend/routes/leaderboard.routes.js
+++ b/backend/routes/leaderboard.routes.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const { getDevsLeaderboard } = require("../controllers/leaderboard.controller");
+
+const router = express.Router();
+
+router.get("/devs", getDevsLeaderboard);
+
+module.exports = router;
+

--- a/backend/server.js
+++ b/backend/server.js
@@ -31,6 +31,10 @@ app.get('/health', (req, res) => {
 const authRoutes = require('./routes/auth.routes');
 app.use('/api/auth', authRoutes);
 
+const leaderboardRoutes = require('./routes/leaderboard.routes');
+app.use('/api/leaderboard', leaderboardRoutes);
+
+
 const {
   globalErrorHandler,
   handleNotFound,

--- a/backend/services/leaderboard.service.js
+++ b/backend/services/leaderboard.service.js
@@ -1,0 +1,49 @@
+const axios = require("axios");
+
+const owner = "Promptzy";
+const repo = "Nexara";
+
+async function getRegularContributors() {
+  try {
+    // 1️⃣ Contributors List
+    const contributorsRes = await axios.get(
+      `https://api.github.com/repos/${owner}/${repo}/contributors`,
+      { headers: { Authorization: `token ${process.env.GITHUB_TOKEN}` } }
+    );
+
+    let contributors = contributorsRes.data
+      .filter(c => !c.login.toLowerCase().includes("gssoc"))
+      .filter(c => !c.login.includes("[bot]"));
+
+    // 2️⃣ Fetch commits + issues closed for each contributor
+    const results = await Promise.all(
+      contributors.map(async (contributor) => {
+        const username = contributor.login;
+
+        // Commits count (same as PRs + direct commits)
+        const commitsCount = contributor.contributions;
+
+        // Issues Closed Count
+        const issuesRes = await axios.get(
+          `https://api.github.com/search/issues?q=repo:${owner}/${repo}+type:issue+state:closed+author:${username}`,
+          { headers: { Authorization: `token ${process.env.GITHUB_TOKEN}` } }
+        );
+        const issuesClosed = issuesRes.data.total_count;
+
+        return {
+          username,
+          prsMerged: contributor.contributions, // here we assume contributions ~ PRs merged
+          commits: commitsCount,
+          issuesClosed: issuesClosed,
+        };
+      })
+    );
+
+    return results;
+  } catch (error) {
+    console.error("Error fetching contributors:", error.message);
+    return [];
+  }
+}
+
+module.exports = { getRegularContributors };


### PR DESCRIPTION
### Summary
- Added new endpoint `/api/leaderboard/devs`
- Returns data for regular contributors (excluding GSSoC participants and bots)
- Each record contains:
  - `username`
  - `prsMerged`
  - `commits`
  - `issuesClosed`
- Designed to integrate with "Regular Contributors" tab in frontend

### Changes made
- backend/controllers/leaderboard.controller.js
- backend/services/leaderboard.service.js
- backend/routes/leaderboard.routes.js
- server.js updated to mount new route

### Testing
- Local test URL: http://localhost:5000/api/leaderboard/devs
- Example response:
{
  "success": true,
  "data": [
    { "username": "Pranjal6955", "prsMerged": 68, "commits": 68, "issuesClosed": 16 },
    ...
  ]
}

### Notes
- Frontend integration pending (can reuse existing leaderboard component)
- No changes to GSSoC logic
Fixes #54 